### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
   <link rel="stylesheet" href="styles.css"/>
 </head>
 <body>
+  <button id="navToggle" class="menu-toggle" aria-expanded="false" aria-controls="sideNav" aria-label="Toggle navigation">&#9776;</button>
   <!-- Fixed side navigation -->
-  <nav id="sideNav">
+  <nav id="sideNav" aria-label="Primary">
     <ul>
       <li><a href="#intro">Intro</a></li>
       <li><a href="#background">Background</a></li>
@@ -230,5 +231,6 @@
       <a href="#">Resume</a>
     </div>
   </footer>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+const nav = document.getElementById('sideNav');
+const toggle = document.getElementById('navToggle');
+
+if (nav && toggle) {
+  toggle.addEventListener('click', () => {
+    const isOpen = nav.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', isOpen);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -499,33 +499,35 @@ a {
   color: #0073a8;
 }
 
-/* Responsive adjustments */
+/* Mobile navigation */
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
 @media (max-width: 768px) {
   #sideNav {
-    position: static;
-    width: 100%;
-    height: auto;
-    border-right: none;
-    border-bottom: 1px solid #e5eff7;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
   }
-  #sideNav ul {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
+
+  #sideNav.open {
+    transform: translateX(0);
   }
-  #sideNav .resume-link {
-    margin-left: auto;
+
+  .menu-toggle {
+    display: block;
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 1000;
   }
+
   .content {
     margin-left: 0;
     padding: 1.5rem;
-  }
-  .intro {
-    min-height: auto;
-    padding-top: 2rem;
   }
 }


### PR DESCRIPTION
## Summary
- add aria-labelled side nav with new hamburger button for small screens
- hide/show side navigation via new mobile CSS rules
- toggle menu state with lightweight JavaScript

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a244c7ffe0833185a88f0148bd439c